### PR TITLE
Fixed problem with two letter nuclei

### DIFF
--- a/src/simpyson/io.py
+++ b/src/simpyson/io.py
@@ -96,7 +96,7 @@ class SimpReader:
                 hz = np.array(hz)
 
                 isotope = int(''.join(filter(str.isdigit, self.nucleus)))
-                element = ''.join(filter(str.isalpha, self.nucleus)).upper()
+                element = ''.join(filter(str.isalpha, self.nucleus)).capitalize()
 
                 b0_unit = ''.join(filter(str.isalpha, self.b0)).lower()
 


### PR DESCRIPTION
Fixed isotope lookup for elements with two letters like 29Si/27Al. The symbol was being incorrectly converted to full uppercase SI/AL causing lookup failures in `isotope_data.json`